### PR TITLE
change to apt

### DIFF
--- a/docs/using-wasabi/InstallPackage.md
+++ b/docs/using-wasabi/InstallPackage.md
@@ -75,7 +75,7 @@ If the message returned says `Good signature from zkSNACKs` and that it was sign
 	:::
 
 4. [GUI] Install by double-clicking and follow the GUI Instruction. </br>
-   [CLI] In the Download repository, execute the command `sudo dpkg -i Wasabi-${currentVersion}.deb` to install Wasabi and after that run Wasabi by executing `wassabee`.
+   [CLI] In the Download repository, execute the command `sudo apt install ./Wasabi-${currentVersion}.deb` to install Wasabi and after that run Wasabi by executing `wassabee`.
 
 After the first run, a [data folder](/FAQ/FAQ-UseWasabi.md#where-can-i-find-the-wasabi-data-folder) will be created.
 Among others, here is where your wallet files and your logs reside.


### PR DESCRIPTION
`dpkg` is the "wrong" command for installing the package, it does not consider dependency downloads.

`apt` uses `dpkg` but also downloads remote packages.

see https://github.com/zkSNACKs/WalletWasabi/pull/9149